### PR TITLE
fix this dumbass bug

### DIFF
--- a/src/vm/lua/LuaVM.hx
+++ b/src/vm/lua/LuaVM.hx
@@ -52,7 +52,7 @@ class LuaVM {
 
 		var result : Any = null;
 		Lua.getglobal(state, name);
-		if(Lua.isfunction(state,-1)){
+		if(Lua.iscfunction(state,-1)){
 			for(arg in args) Convert.toLua(state, arg);
 			result = Lua.pcall(state, args.length, 1, 0);
 


### PR DESCRIPTION
its one character that causes `C:/HaxeToolkit/haxe/lib/hxvm-luajit/git/src/vm/lua/LuaVM.hx:55: lines 55-66 : Int should be Bool` and if you change it to bool it says `C:/HaxeToolkit/haxe/lib/hxvm-luajit/git/src/vm/lua/LuaVM.hx:55: characters 28-32 : Bool should be Int` and its bc the function in the linc_luajit version this thing uses its iscfunction not isfunction aaaaaaaaaaaa